### PR TITLE
Fix for MIDI RX bug

### DIFF
--- a/avr/cores/arcore/MIDIUSB.cpp
+++ b/avr/cores/arcore/MIDIUSB.cpp
@@ -87,7 +87,7 @@ void MIDIUSB_::accept(void)
 
     // while we have room to store a byte
     while (i != buffer->tail) {
-        int c = USB_Recv(CDC_RX);
+        int c = USB_Recv(MIDI_RX);
         if (c == -1)
             break;  // no more data
         buffer->buffer[buffer->head] = c;

--- a/avr/cores/arcore/USBCore.cpp
+++ b/avr/cores/arcore/USBCore.cpp
@@ -630,7 +630,9 @@ ISR(USB_GEN_vect)
 			Serial.accept();
 #endif
 #ifdef MIDI_ENABLED
-		MIDIUSB.accept();
+    USB_Flush(MIDI_TX);
+    if (USB_Available(MIDI_RX))
+		  MIDIUSB.accept();
 #endif
 		// check whether the one-shot period has elapsed.  if so, turn off the LED
 		if (TxLEDPulse && !(--TxLEDPulse))


### PR DESCRIPTION
The MIDIUSB class was trying to receive data from CDC_RX endpoint instead of MIDI_RX endpoint. Probably you forgot to change it when you copied CDC source. :)
