### PR TITLE
Fixing install script for OSX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-HARDWARE=~/Arduino/hardware
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  HARDWARE=~/Arduino/hardware
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  HARDWARE=~/Documents/Arduino/hardware  
+else
+  echo "OS not supported in install script, manually symlink or copy arcore to your Arduino IDE's hardware folder."
+  exit
+fi
 TARGET=$HARDWARE/arcore
 mkdir -p $HARDWARE
 if [[ -d "$TARGET" ]]; then


### PR DESCRIPTION
Sets the library path correctly for OSX to ~/Documents/Arduino.
