### PR TITLE
Added iPad compatibility via extra board type. Cludgy, perhaps, but work...

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -32,3 +32,30 @@ leonardo.build.extra_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid}
 
 ##############################################################
 
+leonardo2.name=Arduino Leonardo (arcore, iPad compatible)
+leonardo2.upload.tool=avrdude
+leonardo2.upload.protocol=avr109
+leonardo2.upload.maximum_size=28672
+leonardo2.upload.speed=57600
+leonardo2.upload.disable_flushing=true
+leonardo2.upload.use_1200bps_touch=true
+leonardo2.upload.wait_for_upload_port=true
+
+leonardo2.bootloader.tool=avrdude
+leonardo2.bootloader.low_fuses=0xff
+leonardo2.bootloader.high_fuses=0xd8
+leonardo2.bootloader.extended_fuses=0xcb
+leonardo2.bootloader.file=caterina/Caterina-Leonardo.hex
+leonardo2.bootloader.unlock_bits=0x3F
+leonardo2.bootloader.lock_bits=0x2F
+
+leonardo2.build.mcu=atmega32u4
+leonardo2.build.f_cpu=16000000L
+leonardo2.build.vid=0x2341
+leonardo2.build.pid=0x8036
+leonardo2.build.board=AVR_LEONARDO
+leonardo2.build.core=arcore
+leonardo2.build.variant=arduino:leonardo
+leonardo2.build.extra_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid} -DIPAD_COMPAT
+
+##############################################################

--- a/avr/cores/arcore/USBCore.h
+++ b/avr/cores/arcore/USBCore.h
@@ -364,8 +364,13 @@ typedef struct
 #define D_DEVICE(_class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs) \
 	{ 18, 1, 0x200, _class,_subClass,_proto,_packetSize0,_vid,_pid,_version,_im,_ip,_is,_configs }
 
-#define D_CONFIG(_totalLength,_interfaces) \
-	{ 9, 2, _totalLength,_interfaces, 1, 0, USB_CONFIG_BUS_POWERED, USB_CONFIG_POWER_MA(500) }
+#ifdef IPAD_COMPAT
+	#define D_CONFIG(_totalLength,_interfaces) \
+		{ 9, 2, _totalLength,_interfaces, 1, 0, USB_CONFIG_BUS_POWERED, USB_CONFIG_POWER_MA(20) }
+#else
+	#define D_CONFIG(_totalLength,_interfaces) \
+		{ 9, 2, _totalLength,_interfaces, 1, 0, USB_CONFIG_BUS_POWERED, USB_CONFIG_POWER_MA(500) }
+#endif
 
 #define D_INTERFACE(_n,_numEndpoints,_class,_subClass,_protocol) \
 	{ 9, 4, _n, 0, _numEndpoints, _class,_subClass, _protocol, 0 }


### PR DESCRIPTION
Hey

Gave this a whirl. Best way I saw to do this is add a second board to the ARcore which has an inline compiler define (-DIPAD_COMPAT, which is equivalent to #define IPAD_COMPAT). We then test for this in USBcore and switch between two current settings (500mA, or 20mA for iPad compatibility).

Let me know what you think - I tested it and it seems to work.

Stefan
